### PR TITLE
Enforce character document IDs on import

### DIFF
--- a/mallet/R/mallet.R
+++ b/mallet/R/mallet.R
@@ -256,6 +256,7 @@ mallet.top.words <- function(topic.model, word.weights, num.top.words=10) {
 #' @export
 mallet.import <- function(id.array, text.array, stoplist.file, preserve.case=FALSE, token.regexp="[\\p{L}]+") {
   stoplist.file <- normalizePath(stoplist.file)
+  id.array <- as.character(id.array)
   if (class(text.array[1]) != "character") stop("Text field is not a string. Remember to create data frames with stringsAsFactors=F.")
   token.pattern <- rJava::J("java/util/regex/Pattern")$compile(token.regexp)
   pipe.list <- rJava::.jnew("java/util/ArrayList")


### PR DESCRIPTION
When `id.array` is not character e.g. `id.array=1:1000` in the `mallet.import` function then the `addInstances` call fails in a way that's really hard to diagnose.